### PR TITLE
Fix not-working commands in the documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Build this image:
 # 
-# sudo docker build -r sfm_image .
+# sudo docker build -t sfm_image .
 
 # Run pipeline on a collection of images in the current working directory:
 #

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -21,7 +21,7 @@ sudo docker run -u $UID -v "$PWD:/data" -i -t nlesc/structure-from-motion /bin/b
 The main script to run the pipeline is called run-sfm.py'.
 The image can also be built from source. To do this yourself, you need to checkout the submodules:
 ````
-git submodule checkout --init --recursive
+git submodule update --init --recursive
 ````
 Then, build the image using the Dockerfile in the repository root directory:
 ````


### PR DESCRIPTION
Hi,

I noticed a typo in the `Dockerfile` comments, and an error with a non-existing `git submodule` command in the documentation. This PR should fix both of them.

Best,
Stéphane